### PR TITLE
Disposing an non-existing image won't fail

### DIFF
--- a/src/main/groovy/de/gesellix/gradle/docker/tasks/DockerDisposeContainerTask.groovy
+++ b/src/main/groovy/de/gesellix/gradle/docker/tasks/DockerDisposeContainerTask.groovy
@@ -1,5 +1,6 @@
 package de.gesellix.gradle.docker.tasks
 
+import de.gesellix.docker.client.DockerClientException
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
@@ -26,7 +27,19 @@ class DockerDisposeContainerTask extends AbstractDockerTask {
     logger.info "docker dispose"
 
     def containerId = getContainerId()
-    def containerDetails = getDockerClient().inspectContainer(containerId)
+    def containerDetails
+    try {
+      containerDetails = getDockerClient().inspectContainer(containerId)
+    }
+    catch (DockerClientException e) {
+      if (e.detail.status.code == 404) {
+        logger.info("couldn't dispose container because it doesn't exists")
+        return
+      }
+      else {
+        throw e
+      }
+    }
     getDockerClient().stop(containerId)
     getDockerClient().wait(containerId)
     getDockerClient().rm(containerId)

--- a/src/test/groovy/de/gesellix/gradle/docker/tasks/DockerDisposeContainerTaskSpec.groovy
+++ b/src/test/groovy/de/gesellix/gradle/docker/tasks/DockerDisposeContainerTaskSpec.groovy
@@ -1,6 +1,7 @@
 package de.gesellix.gradle.docker.tasks
 
 import de.gesellix.docker.client.DockerClient
+import de.gesellix.docker.client.DockerClientException
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
 
@@ -50,5 +51,18 @@ class DockerDisposeContainerTaskSpec extends Specification {
     1 * dockerClient.rm("4712")
     then:
     1 * dockerClient.rmi("an-image-id")
+  }
+
+  def "catches DockerClientException when container is not present"() {
+    given:
+    task.containerId = "4711"
+
+    when:
+    task.execute()
+
+    then:
+    1 * dockerClient.inspectContainer("4711") >> { throw new DockerClientException(new IllegalArgumentException("foo"), [ status: [ code:404]])}
+    then:
+    0 * dockerClient._
   }
 }


### PR DESCRIPTION
Currently disposing an non-existing image fails. Nevertheless the assertion that we want to be clean after disposing the image is true. Therefore we think it is nice to let a dispose of an image succeed  even if the image is not present at all. 